### PR TITLE
19 add legacy inertial frames

### DIFF
--- a/docs/src/Modules/orient_api.md
+++ b/docs/src/Modules/orient_api.md
@@ -54,11 +54,15 @@ This is a list of NAIF IDs for standard axes that are used in astrodynamic appli
     Although they are listed in the public documentation section, these IDs are not directly exported by the package.
 
 ```@docs 
-Orient.AXESID_ICRF
-Orient.AXESID_GCRF
+Orient.AXESID_ECLIPB1950
 Orient.AXESID_ECLIPJ2000
-Orient.AXESID_MEME2000
+Orient.AXESID_FK4
+Orient.AXESID_GALACTIC 
+Orient.AXESID_GCRF
+Orient.AXESID_ICRF
 Orient.AXESID_ITRF
+Orient.AXESID_MEME2000
+Orient.AXESID_MEMEB1950
 Orient.AXESID_MOONME_DE421
 Orient.AXESID_MOONPA_DE421
 Orient.AXESID_MOONPA_DE440
@@ -66,10 +70,17 @@ Orient.AXESID_MOONPA_DE440
 
 ## [Default Rotation Matrices](@id orient_dcms)
 
+!!! note 
+    Although they are listed in the public documentation section, the rotation matrices of some older frames (e.g., B1950, FK4 and GALACTIC) are not exported by the package.
+
 ```@docs 
-Orient.DCM_ICRF_TO_J2000_BIAS
+Orient.DCM_B1950_TO_ECLIPB1950
+Orient.DCM_B1950_TO_FK4
 Orient.DCM_ICRF_TO_ECLIPJ2000
+Orient.DCM_ICRF_TO_J2000_BIAS
+Orient.DCM_FK4_TO_GALACTIC
 Orient.DCM_J2000_TO_ECLIPJ2000
+Orient.DCM_J2000_TO_B1950
 Orient.DCM_MOON_PA421_TO_ME421
 Orient.DCM_MOON_PA430_TO_ME421
 Orient.DCM_MOON_PA430_TO_ME430

--- a/docs/src/Modules/orient_api.md
+++ b/docs/src/Modules/orient_api.md
@@ -54,6 +54,7 @@ This is a list of NAIF IDs for standard axes that are used in astrodynamic appli
     Although they are listed in the public documentation section, these IDs are not directly exported by the package.
 
 ```@docs 
+Orient.AXESID_B1950
 Orient.AXESID_ECLIPB1950
 Orient.AXESID_ECLIPJ2000
 Orient.AXESID_FK4
@@ -62,7 +63,6 @@ Orient.AXESID_GCRF
 Orient.AXESID_ICRF
 Orient.AXESID_ITRF
 Orient.AXESID_MEME2000
-Orient.AXESID_MEMEB1950
 Orient.AXESID_MOONME_DE421
 Orient.AXESID_MOONPA_DE421
 Orient.AXESID_MOONPA_DE440

--- a/src/Orient/Orient.jl
+++ b/src/Orient/Orient.jl
@@ -34,6 +34,7 @@ include("planets.jl")
 
 # Ecliptic 
 include("ecliptic.jl")
+include("legacy.jl")
 
 function __init__()
     if !Tempo.has_timescale(TIMESCALES, Tempo.timescale_id(UT1))

--- a/src/Orient/legacy.jl
+++ b/src/Orient/legacy.jl
@@ -1,0 +1,87 @@
+
+"""
+    AXESID_MEMEB1950
+
+NAIF Axes ID for the Mean Equator and Dynamical Equinox of the Besselian year 1950. 
+"""
+const AXESID_MEMEB1950 = 2
+
+"""
+    AXESID_FK4
+
+NAIF Axes ID for the FK4 reference frame.
+"""
+const AXESID_FK4 = 3
+
+"""
+    AXESID_GALACTIC
+
+NAIF Axes ID for the Galactic System II reference frame.
+"""
+const AXESID_GALACTIC = 13
+
+"""
+    AXESID_ECLIPB1950
+
+NAIF Axes ID for the Mean Ecliptic Equinox of B1950.
+"""
+const AXESID_ECLIPB1950 = 18
+
+"""
+    DCM_J2000_TO_B1950
+
+DCM for the rotation from the Mean Dynamical Equator and Equinox of J2000.0 (`MEME2000`)
+to the Mean Equator and Dynamical Equinox of B1950 (`MEMEB1950`).
+
+!!! note 
+    This rotation is obtained by precessing the J2000 frame backwards from Julian year 2000 
+    to Besselian year 1950, using the 1976 IAU precession model. The rotation values 
+    are taken from the SPICE toolkit. 
+
+### References 
+- SPICE [Library](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/chgirf.html)
+"""
+const DCM_J2000_TO_B1950 = angle_to_dcm(
+    deg2rad(1153.04066200330/3600), -deg2rad(1002.26108439117/3600), 
+    deg2rad(1152.84248596724/3600), :ZYZ
+)
+
+"""
+    DCM_B1950_TO_ECLIPB1950
+
+DCM for the rotation from the Mean Equator and Dynamical Equinox of B1950 (`MEMEB1950`) to
+the Mean Ecliptic Equinox of B1950. This corresponds to the transformation `B1950 -> ECLIPB1950` 
+in the SPICE toolkit, and uses the mean obliquity of the ecliptic from the IAU 1976 theory.
+
+### References 
+- SPICE [Library](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/chgirf.html)
+"""
+const DCM_B1950_TO_ECLIPB1950 = angle_to_dcm(deg2rad(84404.836/3600), :X)
+
+"""
+    DCM_B1950_TO_FK4
+
+DCM for the rotation from the Mean Equator and Dynamical Equinox of B1950 (`MEMEB1950`) ot 
+the FK4 reference frame. 
+
+!!! note 
+    The FK4 reference frame is obtained from the B1950 frame by applying the equinox offset 
+    determined by Fricke.
+
+### References 
+- SPICE [Library](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/chgirf.html)
+"""
+const DCM_B1950_TO_FK4 = angle_to_dcm(deg2rad(0.525/3600), :Z)
+
+"""
+    DCM_FK4_TO_GALACTIC
+
+DCM for the rotation from the FK4 frame to the Galactic System II reference frame.
+
+!!! note 
+    As the SPICE toolkit, we assume that this rotation is derived from the FK4 frame.
+
+### References 
+- SPICE [Library](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/spicelib/chgirf.html)
+"""
+const DCM_FK4_TO_GALACTIC = angle_to_dcm(deg2rad(282.25), deg2rad(62.6), deg2rad(327), :ZXZ)

--- a/src/Orient/legacy.jl
+++ b/src/Orient/legacy.jl
@@ -1,10 +1,10 @@
 
 """
-    AXESID_MEMEB1950
+    AXESID_B1950
 
 NAIF Axes ID for the Mean Equator and Dynamical Equinox of the Besselian year 1950. 
 """
-const AXESID_MEMEB1950 = 2
+const AXESID_B1950 = 2
 
 """
     AXESID_FK4
@@ -31,7 +31,7 @@ const AXESID_ECLIPB1950 = 18
     DCM_J2000_TO_B1950
 
 DCM for the rotation from the Mean Dynamical Equator and Equinox of J2000.0 (`MEME2000`)
-to the Mean Equator and Dynamical Equinox of B1950 (`MEMEB1950`).
+to the Mean Equator and Dynamical Equinox of B1950 (`B1950`).
 
 !!! note 
     This rotation is obtained by precessing the J2000 frame backwards from Julian year 2000 

--- a/test/Orient/Orient.jl
+++ b/test/Orient/Orient.jl
@@ -1,3 +1,4 @@
 
 include("iers.jl")
 include("moon.jl")
+include("legacy.jl")

--- a/test/Orient/legacy.jl
+++ b/test/Orient/legacy.jl
@@ -15,18 +15,18 @@
 
     R = Orient.DCM_J2000_TO_B1950
     Rₑ = pxform("J2000", "B1950", 0.0)
-    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+    @test v2as(R*v, Rₑ*v) ≤ 1e-10
 
     R = Orient.DCM_B1950_TO_FK4
     Rₑ = pxform("B1950", "FK4", 0.0)
-    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+    @test v2as(R*v, Rₑ*v) ≤ 1e-10
 
     R = Orient.DCM_FK4_TO_GALACTIC
     Rₑ = pxform("FK4", "GALACTIC", 0.0)
-    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+    @test v2as(R*v, Rₑ*v) ≤ 1e-10
 
     R = Orient.DCM_B1950_TO_ECLIPB1950
     Rₑ = pxform("B1950", "ECLIPB1950", 0.0)
-    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+    @test v2as(R*v, Rₑ*v) ≤ 1e-10
 
 end;

--- a/test/Orient/legacy.jl
+++ b/test/Orient/legacy.jl
@@ -1,0 +1,32 @@
+
+@testset "legacy" verbose = true begin
+
+    # Test IDs 
+    @test Orient.AXESID_ECLIPB1950 == 18
+    @test Orient.AXESID_FK4 == 3
+    @test Orient.AXESID_GALACTIC == 13
+    @test Orient.AXESID_MEMEB1950 == 2
+
+    # Function to compute the angle between 2 vectors in arcseconds
+    v2as = (x, y) -> acosd(max(-1, min(1, dot(x / norm(x), y / norm(y))))) * 3600
+
+    v = rand(BigFloat, 3)
+    v /= norm(v)
+
+    R = Orient.DCM_J2000_TO_B1950
+    Rₑ = pxform("J2000", "B1950", 0.0)
+    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+
+    R = Orient.DCM_B1950_TO_FK4
+    Rₑ = pxform("B1950", "FK4", 0.0)
+    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+
+    R = Orient.DCM_FK4_TO_GALACTIC
+    Rₑ = pxform("FK4", "GALACTIC", 0.0)
+    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+
+    R = Orient.DCM_B1950_TO_ECLIPB1950
+    Rₑ = pxform("B1950", "ECLIPB1950", 0.0)
+    @test v2as(R*v, Rₑ*v) ≤ 1e-11
+
+end;


### PR DESCRIPTION
Closes #19. Legacy rotations have been added to Orient but are not exported. High-level methods to add those axes to the frame system have not been implemented because of the limited use cases.